### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-03-18
+
+### Fixed
+
+- **npm package contents** — packed artifacts now reliably include `dist/*`, and CI smoke-checks the tarball contents before release.
+- **TypeScript test workflow** — `npm test` now uses the same `tsx`-based path exercised in CI, fixing the local `ERR_MODULE_NOT_FOUND` failure mode.
+- **Channel subscriptions** — `subscribe()` now validates channels up front, uses per-channel events, and surfaces initial drain errors instead of silently swallowing them.
+- **Documentation accuracy** — aligned workspace/package version strings, fixed the plugin README import example, corrected ordered-channel wording, and refined the README positioning without dropping the drop-in replacement claim.
+
 ## [2.1.0] - 2026-03-17
 
 ### Performance — Rust core (conduit-core)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "conduit-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "conduit-derive",
  "criterion",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-derive"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "conduit-core",
  "proc-macro2",
@@ -771,7 +771,7 @@ checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tauri-conduit"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "conduit-core",
  "conduit-derive",

--- a/crates/conduit-core/Cargo.toml
+++ b/crates/conduit-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit-core"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ serde = { version = "1", features = ["derive"] }
 sonic-rs = "0.3"
 
 [dev-dependencies]
-conduit-derive = { version = "2.1.0", path = "../conduit-derive" }
+conduit-derive = { version = "2.1.1", path = "../conduit-derive" }
 criterion = { version = "0.5", features = ["html_reports"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/crates/conduit-core/README.md
+++ b/crates/conduit-core/README.md
@@ -7,7 +7,7 @@
 
 Binary IPC core for Tauri v2: codec, router, ring buffer, and ordered queue.
 
-Part of the [tauri-conduit](https://github.com/userFRM/tauri-conduit) workspace (v2.1.0).
+Part of the [tauri-conduit](https://github.com/userFRM/tauri-conduit) workspace (v2.1.1).
 
 ## Features
 

--- a/crates/conduit-derive/Cargo.toml
+++ b/crates/conduit-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit-derive"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -20,7 +20,7 @@ quote = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-conduit-core = { version = "2.1.0", path = "../conduit-core" }
+conduit-core = { version = "2.1.1", path = "../conduit-core" }
 serde_json = "1"
 sonic-rs = "0.3"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/conduit-derive/README.md
+++ b/crates/conduit-derive/README.md
@@ -7,7 +7,7 @@
 
 Proc macros for [conduit-core](https://crates.io/crates/conduit-core): `#[derive(Encode, Decode)]`, `#[command]`, and `handler!()`.
 
-Part of the [tauri-conduit](https://github.com/userFRM/tauri-conduit) workspace (v2.1.0).
+Part of the [tauri-conduit](https://github.com/userFRM/tauri-conduit) workspace (v2.1.1).
 
 ## Usage
 

--- a/crates/conduit/Cargo.toml
+++ b/crates/conduit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-conduit"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -10,5 +10,5 @@ homepage = "https://github.com/userFRM/tauri-conduit"
 readme = "README.md"
 
 [dependencies]
-conduit-derive = { version = "2.1.0", path = "../conduit-derive" }
-conduit-core = { version = "2.1.0", path = "../conduit-core" }
+conduit-derive = { version = "2.1.1", path = "../conduit-derive" }
+conduit-core = { version = "2.1.1", path = "../conduit-core" }

--- a/crates/tauri-plugin-conduit/Cargo.lock
+++ b/crates/tauri-plugin-conduit/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "serde",
  "sonic-rs",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "conduit-derive"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-conduit"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "conduit-core",
  "conduit-derive",

--- a/crates/tauri-plugin-conduit/Cargo.toml
+++ b/crates/tauri-plugin-conduit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-conduit"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -13,8 +13,8 @@ readme = "README.md"
 links = "tauri-plugin-conduit"
 
 [dependencies]
-conduit-core = { version = "2.1.0", path = "../conduit-core" }
-conduit-derive = { version = "2.1.0", path = "../conduit-derive" }
+conduit-core = { version = "2.1.1", path = "../conduit-core" }
+conduit-derive = { version = "2.1.1", path = "../conduit-derive" }
 tauri = "2"
 tauri-plugin = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/tauri-plugin-conduit/README.md
+++ b/crates/tauri-plugin-conduit/README.md
@@ -7,7 +7,7 @@
 
 Tauri v2 plugin for [conduit](https://github.com/userFRM/tauri-conduit) -- binary IPC over the `conduit://` custom protocol.
 
-Part of the [tauri-conduit](https://github.com/userFRM/tauri-conduit) workspace (v2.1.0).
+Part of the [tauri-conduit](https://github.com/userFRM/tauri-conduit) workspace (v2.1.1).
 
 ## Usage
 

--- a/packages/tauri-plugin-conduit/package-lock.json
+++ b/packages/tauri-plugin-conduit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tauri-plugin-conduit",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tauri-plugin-conduit",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/packages/tauri-plugin-conduit/package.json
+++ b/packages/tauri-plugin-conduit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-plugin-conduit",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Drop-in replacement for Tauri's invoke(). One import change, zero config. Binary IPC under the hood.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump all Rust crates and the npm package from `2.1.0` to `2.1.1`
- update internal dependency pins and lockfiles so the release version is fully synchronized
- add a `2.1.1` changelog entry covering the packaging, CI, subscription, and documentation fixes already merged

## Verification
- `cargo test`
- `cargo test --manifest-path crates/tauri-plugin-conduit/Cargo.toml`
- `cd packages/tauri-plugin-conduit && npm test`
- `cd packages/tauri-plugin-conduit && npm run check`
- `cd packages/tauri-plugin-conduit && npm run build && npm pack --dry-run 2>&1 | tee /tmp/tauri-plugin-conduit-pack-2.1.1.txt >/dev/null && grep 'dist/index.js' /tmp/tauri-plugin-conduit-pack-2.1.1.txt`
